### PR TITLE
Bug with MDB_NUMERIC fields

### DIFF
--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -715,7 +715,7 @@ mdb_num_to_string(MdbHandle *mdb, int start, int datatype, int prec, int scale)
 	text = (char *) g_malloc(prec+2);
 	sprintf(text, "%0*" G_GINT32_FORMAT, prec, GINT32_FROM_LE(l));
 	if (scale) {
-		memmove(text+prec-scale, text+prec-scale+1, scale+1);
+		memmove(text+prec-scale+1, text+prec-scale, scale+1);
 		text[prec-scale] = '.';
 	}
 	return text;


### PR DESCRIPTION
Dear Brian,

As I already reported on the mailing list, there's a bug in libmdb that causes NUMERIC fields to be displayed incorrectly. This pull request contains the seemingly trivial modification I already suggested in the email.

Best regards,
Jakob Egger
