### PR TITLE
Segmentation Fault on some DB

### DIFF
--- a/src/libmdb/iconv.c
+++ b/src/libmdb/iconv.c
@@ -30,6 +30,7 @@ int
 mdb_unicode2ascii(MdbHandle *mdb, char *src, size_t slen, char *dest, size_t dlen)
 {
 	char *tmp = NULL;
+	unsigned int compress = 0;
 	size_t tlen = 0;
 	size_t len_in, len_out;
 	char *in_ptr, *out_ptr;
@@ -40,7 +41,7 @@ mdb_unicode2ascii(MdbHandle *mdb, char *src, size_t slen, char *dest, size_t dle
 	/* Uncompress 'Unicode Compressed' string into tmp */
 	if (!IS_JET3(mdb) && (slen>=2)
 	 && ((src[0]&0xff)==0xff) && ((src[1]&0xff)==0xfe)) {
-		unsigned int compress=1;
+		compress=1;
 		src += 2;
 		slen -= 2;
 		tmp = (char *)g_malloc(slen*2);
@@ -72,15 +73,15 @@ mdb_unicode2ascii(MdbHandle *mdb, char *src, size_t slen, char *dest, size_t dle
 		iconv(mdb->iconv_in, &in_ptr, &len_in, &out_ptr, &len_out);
 		if ((!len_in) || (errno == E2BIG)) break;
 		/* Don't bail if impossible conversion is encountered */
-		in_ptr += (IS_JET3(mdb)) ? 1 : 2;
-		len_in -= (IS_JET3(mdb)) ? 1 : 2;
+		in_ptr += compress ? 2 : 1;
+		len_in -= compress ? 2 : 1;
 		*out_ptr++ = '?';
 		len_out--;
 	}
 	//printf("2 len_in %d len_out %d\n",len_in, len_out);
 	dlen -= len_out;
 #else
-	if (IS_JET3(mdb)) {
+	if (!compress) {
                size_t copy_len = len_in;
                if (copy_len > dlen)
                        copy_len = dlen;


### PR DESCRIPTION
Hi,

There is a kind of database I can't get to read with mdb-tools, I can send you such a DB if you want...

Here is a BT:

mdb-export Halley_20121121_110309.dc3db DB_VALUES
KeyID,ValueName,Type,Size,Data,LongData,LinkedTable
Segmentation fault

gdb bt full:
#0  0x00002aaaaaac305c in mdb_unicode2ascii (mdb=0x605020, src=0x605f1a "X@\325\310\062", slen=255, dest=0x62d050 "䁘죕2", dlen=16384) at iconv.c:77

```
    tmp = 0x0
    tlen = 0
    len_in = 18446744073709363637
    len_out = 18446744073709473872
    in_ptr = 0x633e64 '?' <repeats 200 times>...
    out_ptr = 0x644000 <Address 0x644000 out of bounds>
```
#1  0x00002aaaaaaba658 in mdb_col_to_string (mdb=0x605020, buf=0x605034, start=3814, datatype=9, size=255) at data.c:938

```
    text = 0x62d050 "䁘죕2"
    tf = 4.20389539e-45
    td = 3.1759567371218678e-317
```
#2  0x00002aaaaaab8b0b in mdb_xfer_bound_data (mdb=0x605020, start=3814, col=0x618110, len=255) at data.c:228

```
    str = 0x62aab0 "h:\325\310\062"
    ret = 1
```
#3  0x00002aaaaaab8e32 in _mdb_attempt_bind (mdb=0x605020, col=0x618110, isnull=0 '\000', offset=3814, len=255) at data.c:313

No locals.
#4  0x00002aaaaaab8d74 in mdb_read_row (table=0x617800, row=0) at data.c:291

```
    mdb = 0x605020
    col = 0x618110
    i = 4
    row_start = 3802
    row_size = 294
    delflag = 0
    lookupflag = 0
    fields = {{value = 0x605f10, siz = 4, start = 3804, is_null = 0 '\000', is_fixed = 1 '\001', colnum = 0, offset = 0}, {value = 0x606019, siz = 16, 
        start = 4069, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 1, offset = 0}, {value = 0x605f14, siz = 2, start = 3808, is_null = 0 '\000', 
        is_fixed = 1 '\001', colnum = 2, offset = 0}, {value = 0x605f16, siz = 4, start = 3810, is_null = 0 '\000', is_fixed = 1 '\001', colnum = 3, 
        offset = 0}, {value = 0x605f1a, siz = 255, start = 3814, is_null = 0 '\000', is_fixed = 1 '\001', colnum = 4, offset = 0}, {value = 0x606029, siz = 0, 
        start = 4085, is_null = 1 '\001', is_fixed = 0 '\000', colnum = 5, offset = 0}, {value = 0x606029, siz = 0, start = 4085, is_null = 1 '\001', 
        is_fixed = 0 '\000', colnum = 6, offset = 0}, {value = 0x0, siz = 0, start = 0, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, 
        offset = 0} <repeats 109 times>, {value = 0x0, siz = 0, start = 0, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, offset = -933208261}, {
        value = 0x0, siz = 0, start = 0, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, offset = 0}, {value = 0x0, siz = 0, start = 0, is_null = 0 '\000', 
        is_fixed = 0 '\000', colnum = 0, offset = 0}, {value = 0x32c9a00000, siz = -912171008, start = 50, is_null = 112 'p', is_fixed = 90 'Z', colnum = 50, 
        offset = -912172432}, {value = 0x0, siz = 5, start = 0, is_null = 0 '\000', is_fixed = 80 'P', colnum = 50, offset = -910069760}, {value = 0x32c9c16250, 
        siz = -910056592, start = 50, is_null = 0 '\000', is_fixed = 80 'P', colnum = 0, offset = 3}, {value = 0x0, siz = 0, start = 0, is_null = 0 '\000', 
        is_fixed = 0 '\000', colnum = 0, offset = 0}, {value = 0x606034, siz = -1431604865, start = 10922, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, 
        offset = 6311968}, {value = 0xe480101, siz = 0, start = 263913478, is_null = 118 'v', is_fixed = 15 '\017', colnum = 245829356, offset = 3682}, {
        value = 0x0, siz = 0, start = 0, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, offset = 0} <repeats 108 times>, {value = 0x0, siz = 0, start = 0, 
        is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, offset = -933196697}, {value = 0x0, siz = -1429366072, start = 10922, is_null = 3 '\003', 
        is_fixed = 0 '\000', colnum = 0, offset = 7}, {value = 0x1c93965e, siz = -933195676, start = 50, is_null = 56 '8', is_fixed = 132 '\204', colnum = 0, 
        offset = -6336}, {value = 0x1c93965e, siz = -5936, start = 32767, is_null = 232 '\350', is_fixed = 232 '\350', colnum = 32767, offset = -929023352}, {
        value = 0x0, siz = -933196544, start = 50, is_null = 8 '\b', is_fixed = 11 '\v', colnum = 10922, offset = -1429366088}, {value = 0x1, siz = -1431605209,
        start = 10922, is_null = 0 '\000', is_fixed = 16 '\020', colnum = 0, offset = 27}, {value = 0x605034, siz = 6311968, start = 0, is_null = 24 '\030', 
        is_fixed = 90 'Z', colnum = 0, offset = -5824}, {value = 0x7fffffffe958, siz = -1431628216, start = 10922, is_null = 0 '\000', is_fixed = 0 '\000', 
        colnum = 0, offset = 0}, {value = 0x2aaaaaab0168, siz = 4195932, start = 0, is_null = 0 '\000', is_fixed = 43 '+', colnum = 10922, offset = 4195464}, {
        value = 0x100000000, siz = 197, start = 1, is_null = 4 '\004', is_fixed = 0 '\000', colnum = 0, offset = -1431637152}, {value = 0x7fffffffe990, 
        siz = -5824, start = 32767, is_null = 24 '\030', is_fixed = 90 'Z', colnum = 0, offset = -5800}, {value = 0x0, siz = -933195166, start = 50, 
        is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, offset = 0}, {value = 0x1, siz = 0, start = 0, is_null = 1 '\001', is_fixed = 0 '\000', 
        colnum = 50, offset = -925550080}, {value = 0x0, siz = 0, start = 0, is_null = 32 ' ', is_fixed = 243 '\363', colnum = 0, offset = -5768}, {
        value = 0x10062aac6, siz = 0, start = 0, is_null = 96 '`', is_fixed = 243 '\363', colnum = 10922, offset = -5696}, {value = 0x19, siz = 479657997, 
        start = 0, is_null = 1 '\001', is_fixed = 0 '\000', colnum = 0, offset = 33188}, {value = 0x1f8, siz = 0, start = 0, is_null = 0 '\000', 
        is_fixed = 96 '`', colnum = 0, offset = 4096}, {value = 0x3948, siz = 1353582774, start = 0, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, 
        offset = 1353502564}, {value = 0x0, siz = 1353511623, start = 0, is_null = 0 '\000', is_fixed = 0 '\000', colnum = 0, offset = 0}, {value = 0x0, 
        siz = 0, start = 0, is_null = 0 '\000', is_fixed = 16 '\020', colnum = 0, offset = 110592}, {value = 0x7fffffffe980, siz = -1431605578, start = 10922, 
        is_null = 128 '\200', is_fixed = 233 '\351', colnum = 32767, offset = 4096}, {value = 0x40000001b, siz = 6311988, start = 0, is_null = 192 '\300', 
        is_fixed = 121 'y', colnum = 0, offset = 4096}, {value = 0x7fffffffe9d0, siz = -1431597297, start = 10922, is_null = 0 '\000', is_fixed = 0 '\000', 
        colnum = 0, offset = -933179643}}
    num_fields = 7
```
#5  0x00002aaaaaab92c7 in mdb_fetch_row (table=0x617800) at data.c:423

```
    mdb = 0x605020
    fmt = 0x2aaaaacc7380
    rows = 12
    rc = 10922
    pg = 0
```
#6  0x0000000000401712 in main (argc=3, argv=0x7fffffffebc8) at mdb-export.c:203

```
    j = 7
    mdb = 0x605020
    table = 0x617800
    col = 0x618430
    bound_values = 0x621600
    bound_lens = 0x6185c0
    delimiter = 0x603fd0 ","
    row_delimiter = 0x605000 "\n"
    quote_char = 0x603fb0 "\""
    escape_char = 0x0
    header_row = 1 '\001'
    quote_text = 1 '\001'
    insert_dialect = 0x0
    namespace = 0x0
    opt = -1
    value = 0x0
    length = 46912496222157
```
