### PR TITLE
FIX: mdb-sql crashed with SIGSEGV in _IO_vfprintf_internal() on amd64

### DIFF
--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -51,10 +51,13 @@ mdb_sql_error(MdbSQL* sql, char *fmt, ...)
 va_list ap;
 
 	va_start(ap, fmt);
-	vfprintf (stderr, fmt, ap);
-	vsprintf(sql->error_msg, fmt, ap);
+	vfprintf(stderr, fmt, ap);
 	va_end(ap);
 	fprintf(stderr,"\n");
+
+	va_start(ap, fmt);
+	vsprintf(sql->error_msg, fmt, ap);
+	va_end(ap);
 }
 
 int mdb_sql_yyinput(char *buf, int need)


### PR DESCRIPTION
https://bugs.launchpad.net/ubuntu/+source/mdbtools/+bug/1227033
