### PR TITLE
Fixes build error introduced by previous commit

### DIFF
--- a/src/sql/Makefile.am
+++ b/src/sql/Makefile.am
@@ -1,8 +1,9 @@
+BUILT_SOURCES = parser.h
+AM_YFLAGS = -d
 lib_LTLIBRARIES	=	libmdbsql.la
 libmdbsql_la_SOURCES=	mdbsql.c parser.y lexer.l 
 libmdbsql_la_LDFLAGS = -version-info 2:0:0 -export-symbols-regex '^mdb_sql_'
 CLEANFILES = parser.c parser.h lexer.c
-BUILT_SOURCES = parser.h
 AM_CFLAGS	=	-I$(top_srcdir)/include $(GLIB_CFLAGS)
 LIBS	=	$(GLIB_LIBS)
 libmdbsql_la_LIBADD =	../libmdb/libmdb.la


### PR DESCRIPTION
It seems that the BUILT_SOURCES line needs to go before the LIB_LIBRARIES line otherwise make complains
(See issue #33 for original discussion)
