### PR TITLE
remove unneeded headers

### DIFF
--- a/src/extras/mdb-dump.c
+++ b/src/extras/mdb-dump.c
@@ -3,10 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <netdb.h>
-#include <sys/types.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 #include <time.h>
 #include <limits.h>
 #include <assert.h>


### PR DESCRIPTION
This is a tiny tweak to remove some `#include`s that are not needed, to make compilation easier on a platform without  those header files.
