### PR TITLE
Build system picks up libmdb from system instead of newly build one

### DIFF
--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -1,9 +1,8 @@
 bin_PROGRAMS	=	mdb-export mdb-array mdb-schema mdb-tables mdb-parsecsv mdb-header mdb-sql mdb-ver mdb-prop 
 noinst_PROGRAMS = mdb-import prtable prcat prdata prkkd prdump prole updrow prindex
-LIBS	=	$(GLIB_LIBS) @LIBS@ @LEXLIB@ 
+LIBS	=	../libmdb/libmdb.la $(GLIB_LIBS) @LIBS@ @LEXLIB@ 
 DEFS = @DEFS@ -DLOCALEDIR=\"$(localedir)\"
 AM_CFLAGS	=	-I$(top_srcdir)/include $(GLIB_CFLAGS)
-LDADD	=	../libmdb/libmdb.la 
 if SQL
 mdb_sql_LDADD = ../libmdb/libmdb.la ../sql/libmdbsql.la $(LIBREADLINE)
 endif


### PR DESCRIPTION
While working on OpenBSD port update I noticed that build fails after an attempt at linking executables against libmdb with the following error:

    mdb-export.o(.text.startup+0x929): In function `main':
    : undefined reference to `mdb_ole_read_full'
    collect2: error: ld returned 1 exit status

Apparently the issue is with oder of linker flags: newly built libmdb is mentioned after after system library path, so linker picks up system libmdb. Proposed fix is to change `src/util/Makefile.am` to put `../libmdb/libmdb.la` in front of linker flags explicitly.

(Sorry for duplication pull request #66 - it died during my attempt at syncing my fork with this repo.)