### PR TITLE
Implemented SQL_DESC_UNSIGNED attribute in SQLColAttributes

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -939,6 +939,21 @@ static SQLRETURN SQL_API _SQLColAttributes(
 		case SQL_COLUMN_DISPLAY_SIZE: /* =SQL_DESC_DISPLAY_SIZE */
 			*pfDesc = mdb_col_disp_size(col);
 			break;
+        case SQL_DESC_UNSIGNED:
+			switch(col->col_type) {
+				case MDB_INT:
+				case MDB_LONGINT:
+				case MDB_FLOAT:
+				case MDB_DOUBLE:
+				case MDB_NUMERIC:
+					*pfDesc = SQL_FALSE;
+					break;
+				case MDB_BYTE:
+				default: // Everything else returns true per MSDN
+					*pfDesc = SQL_TRUE;
+					break;
+			}
+			break;
 		default:
 			strcpy(sqlState, "HYC00"); // 	Driver not capable
 			ret = SQL_ERROR;

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1300,6 +1300,7 @@ static SQLRETURN SQL_API _SQLFreeEnv(
 		return SQL_ERROR;
 	}
 	g_ptr_array_free(env->connections, TRUE);
+	mdb_sql_exit(env->sql);
 	g_free(env);
 
 	return SQL_SUCCESS;

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1300,6 +1300,7 @@ static SQLRETURN SQL_API _SQLFreeEnv(
 		return SQL_ERROR;
 	}
 	g_ptr_array_free(env->connections, TRUE);
+	g_free(env);
 
 	return SQL_SUCCESS;
 }

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1797,7 +1797,7 @@ static SQLRETURN SQL_API _SQLGetData(
 		{
 			char *str = mdb_col_to_string(mdb, mdb->pg_buf,
 				col->cur_value_start, col->col_type, col->cur_value_len);
-			int len = strlen(str) + 1; // including \0
+			int len = strlen(str);
 			if (stmt->pos >= len) {
 				free(str);
 				return SQL_NO_DATA;

--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -457,9 +457,18 @@ void mdb_sql_dump(MdbSQL *sql)
 }
 void mdb_sql_exit(MdbSQL *sql)
 {
-	mdb_sql_reset(sql); // Free memory
+	/* Free the memory associated with the SQL engine */
+	mdb_sql_reset(sql);
+	
+	g_ptr_array_free(sql->columns, TRUE);
+	g_ptr_array_free(sql->tables, TRUE);
+	
+	/* If libmdb has been initialized, terminate it */
 	if (sql->mdb)
 		mdb_close(sql->mdb);
+	
+	/* Cleanup the SQL engine object */
+	g_free(sql);
 }
 void mdb_sql_reset(MdbSQL *sql)
 {

--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -473,6 +473,13 @@ void mdb_sql_reset(MdbSQL *sql)
 		sql->cur_table = NULL;
 	}
 
+	/* Reset bound values */
+	unsigned int i;
+	for (i=0;i<sql->num_columns;i++) {
+		g_free(sql->bound_values[i]);
+		sql->bound_values[i] = NULL;
+	}
+
 	/* Reset columns */
 	mdb_sql_free_columns(sql->columns);
 	sql->num_columns = 0;

--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -205,14 +205,14 @@ run_query(FILE *out, MdbSQL *sql, char *mybuf, char *delimiter)
 			else 
 				printf("Index scanning %s using %s\n", table->name, table->scan_idx->name);
 		}
-		if (noexec) {
-			mdb_sql_reset(sql);
-			return;
+		/* If noexec != on, dump results */
+		if (!noexec) {
+			if (pretty_print)
+				dump_results_pp(out, sql);
+			else
+				dump_results(out, sql, delimiter);
 		}
-		if (pretty_print)
-			dump_results_pp(out, sql);
-		else
-			dump_results(out, sql, delimiter);
+		mdb_sql_reset(sql);
 	}
 }
 
@@ -281,8 +281,6 @@ dump_results(FILE *out, MdbSQL *sql, char *delimiter)
 	if (footers) {
 		print_rows_retrieved(out, row_count);
 	}
-
-	mdb_sql_reset(sql);
 }
 
 void 
@@ -343,8 +341,6 @@ dump_results_pp(FILE *out, MdbSQL *sql)
 	for (j=0;j<sql->num_columns;j++) {
 		g_free(sql->bound_values[j]);
 	}
-
-	mdb_sql_reset(sql);
 }
 
 int

--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -336,11 +336,6 @@ dump_results_pp(FILE *out, MdbSQL *sql)
 	if (footers) {
 		print_rows_retrieved(out, row_count);
 	}
-
-	/* clean up */
-	for (j=0;j<sql->num_columns;j++) {
-		g_free(sql->bound_values[j]);
-	}
 }
 
 int


### PR DESCRIPTION
Referred to MSDN documents about Access datatypes to implement this attribute.  Note that MSDN documents say that the Windows Access ODBC driver returns SQL_TRUE for all non-numeric datatypes, so this attribute was written to mirror that behavior.