### PR TITLE
mdb-export: Add boolean words option (TRUE/FALSE)

### DIFF
--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -496,6 +496,7 @@ extern size_t mdb_ole_read_next(MdbHandle *mdb, MdbColumn *col, void *ole_ptr);
 extern size_t mdb_ole_read(MdbHandle *mdb, MdbColumn *col, void *ole_ptr, int chunk_size);
 extern void* mdb_ole_read_full(MdbHandle *mdb, MdbColumn *col, size_t *size);
 extern void mdb_set_date_fmt(const char *);
+extern void mdb_set_boolean_fmt_words();
 extern int mdb_read_row(MdbTableDef *table, unsigned int row);
 
 /* dump.c */

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -89,6 +89,7 @@ main(int argc, char **argv)
 	char *escape_char = NULL;
 	int header_row = 1;
 	int quote_text = 1;
+	int boolean_words = 0;
 	char *insert_dialect = NULL;
 	char *date_fmt = NULL;
 	char *namespace = NULL;
@@ -108,6 +109,7 @@ main(int argc, char **argv)
 		{ "escape", 'X', 0, G_OPTION_ARG_STRING, &escape_char, "Use <char> to escape quoted characters within a field. Default is doubling.", "format"},
 		{ "namespace", 'N', 0, G_OPTION_ARG_STRING, &namespace, "Prefix identifiers with namespace", "namespace"},
 		{ "bin", 'b', 0, G_OPTION_ARG_STRING, &str_bin_mode, "Binary export mode", "strip|raw|octal"},
+		{ "boolean-words", 'B', 0, G_OPTION_ARG_NONE, &boolean_words, "Use TRUE/FALSE in Boolean fields (default is 0/1)", NULL},
 		{ NULL },
 	};
 	GError *error = NULL;
@@ -153,6 +155,9 @@ main(int argc, char **argv)
 
 	if (date_fmt)
 		mdb_set_date_fmt(date_fmt);
+
+	if (boolean_words)
+		mdb_set_boolean_fmt_words();
 
 	if (str_bin_mode) {
 		if (!strcmp(str_bin_mode, "strip"))


### PR DESCRIPTION
Adds "-B" (--boolean-words) option to mdb-export, which will reconfigure
mdb/data.c to export TRUE/FALSE for boolean values instead of 1/0.  The
option is needed to support BOOLEAN fields on PostgreSQL, which will not
implicitly cast bare 1/0 into a BOOLEAN value.  PostgreSQL supported
Boolean literals are the SQL TRUE/FALSE, and _quoted_ words meaning 
true/false and _quoted_ '1'/'0'.  With this flag the SQL TRUE/FALSE values 
are output, which should work with several SQL databases.

PostgreSQL Reference:

http://www.postgresql.org/docs/current/static/datatype-boolean.html