### PR TITLE
Adding option for user-defined NULL token in CSV output

### DIFF
--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -93,6 +93,7 @@ main(int argc, char **argv)
 	char *date_fmt = NULL;
 	char *namespace = NULL;
 	char *str_bin_mode = NULL;
+	char *null_text = NULL;
 	int bin_mode = MDB_BINEXPORT_RAW;
 	char *value;
 	size_t length;
@@ -107,6 +108,7 @@ main(int argc, char **argv)
 		{ "date_format", 'D', 0, G_OPTION_ARG_STRING, &date_fmt, "Set the date format (see strftime(3) for details)", "format"},
 		{ "escape", 'X', 0, G_OPTION_ARG_STRING, &escape_char, "Use <char> to escape quoted characters within a field. Default is doubling.", "format"},
 		{ "namespace", 'N', 0, G_OPTION_ARG_STRING, &namespace, "Prefix identifiers with namespace", "namespace"},
+		{ "null", '0', 0, G_OPTION_ARG_STRING, &null_text, "Use <char> to represent a NULL value", "char"},
 		{ "bin", 'b', 0, G_OPTION_ARG_STRING, &str_bin_mode, "Binary export mode", "strip|raw|octal"},
 		{ NULL },
 	};
@@ -153,6 +155,11 @@ main(int argc, char **argv)
 
 	if (date_fmt)
 		mdb_set_date_fmt(date_fmt);
+		
+	if (null_text)
+		null_text = escapes(null_text);
+	else
+		null_text = g_strdup("");
 
 	if (str_bin_mode) {
 		if (!strcmp(str_bin_mode, "strip"))
@@ -233,6 +240,8 @@ main(int argc, char **argv)
 				/* Don't quote NULLs */
 				if (insert_dialect)
 					fputs("NULL", outfile);
+				else
+					fputs(null_text, outfile);
 			} else {
 				if (col->col_type == MDB_OLE) {
 					value = mdb_ole_read_full(mdb, col, &length);


### PR DESCRIPTION
Allows CSV outputs with a user-defined NULL token. For example, this enables importing of CSV dumps into MySQL. It would be possible to use -I and generate INSERT statements, but that can take a 1 minute process and turn it into 45 minutes..

Very minor changes here -- adding a command line option to specify a string to use as placeholder for NULL values. Not sure if it should be passed through `escapes`, but it works for simple cases.