### PR TITLE
Allow mdb_open_buffer to work when fmemopen not available

### DIFF
--- a/include/mdbtools.h.in
+++ b/include/mdbtools.h.in
@@ -256,6 +256,8 @@ typedef struct {
 
 typedef struct {
 	FILE        *stream;
+	void		*data;
+	size_t		data_len;
 	gboolean      writable;
 	guint32		jet_version;
 	guint32		db_key;


### PR DESCRIPTION
This patch fixes `mdb_open_buffer` to work on platforms where `fmemopen` is not available, such as Windows.